### PR TITLE
Fix CO-FUNC-009: OPTIONS coverage and protected-route behavior for orders/payment methods

### DIFF
--- a/routes/orders.py
+++ b/routes/orders.py
@@ -66,7 +66,7 @@ def ensure_payment_method(uid: int, payment_method_id: int | None):
     return None, error("validation_error", "no payment methods on file", 400)
 
 
-@bp.get("/orders")
+@bp.route("/orders", methods=["GET"], provide_automatic_options=False)
 def list_orders():
     uid, err = require_user_id()
     if err:
@@ -80,7 +80,7 @@ def list_orders():
     return {"items": [order_to_dict(o, include_items=False) for o in orders]}, 200
 
 
-@bp.get("/orders/<int:order_id>")
+@bp.route("/orders/<int:order_id>", methods=["GET"], provide_automatic_options=False)
 def get_order(order_id: int):
     uid, err = require_user_id()
     if err:
@@ -95,7 +95,7 @@ def get_order(order_id: int):
     return order_to_dict(order, include_items=True), 200
 
 
-@bp.post("/orders")
+@bp.route("/orders", methods=["POST"], provide_automatic_options=False)
 def create_order():
     """
     Checkout:
@@ -200,7 +200,7 @@ def create_order():
     }, 201
 
 
-@bp.patch("/orders/<int:order_id>")
+@bp.route("/orders/<int:order_id>", methods=["PATCH"], provide_automatic_options=False)
 def patch_order(order_id: int):
     """
     Limited state transitions:
@@ -233,7 +233,7 @@ def patch_order(order_id: int):
     return order_to_dict(order, include_items=False), 200
 
 
-@bp.delete("/orders/<int:order_id>")
+@bp.route("/orders/<int:order_id>", methods=["DELETE"], provide_automatic_options=False)
 def delete_order(order_id: int):
     """
     Prefer soft-cancel: set status=cancelled.
@@ -256,10 +256,19 @@ def delete_order(order_id: int):
 
 
 @bp.route("/orders", methods=["OPTIONS"])
-@bp.route("/orders/<int:order_id>", methods=["OPTIONS"])
-def orders_options(order_id: int | None = None):
+def orders_options_collection():
     resp = make_response("", 204)
-    resp.headers["Allow"] = "GET,POST,PATCH,DELETE,OPTIONS"
-    resp.headers["Access-Control-Allow-Methods"] = "GET,POST,PATCH,DELETE,OPTIONS"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    allow = "GET,POST,OPTIONS"
+    resp.headers["Allow"] = allow
+    resp.headers["Access-Control-Allow-Methods"] = allow
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    return resp
+
+@bp.route("/orders/<int:order_id>", methods=["OPTIONS"])
+def orders_options_item(order_id):
+    resp = make_response("", 204)
+    allow = "GET,PATCH,DELETE,OPTIONS"
+    resp.headers["Allow"] = allow
+    resp.headers["Access-Control-Allow-Methods"] = allow
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
     return resp

--- a/routes/payment_methods.py
+++ b/routes/payment_methods.py
@@ -119,7 +119,7 @@ def apply_default_rule(uid: int, pm: PaymentMethod, want_default: bool):
     pm.is_default = True
 
 
-@bp.get("/payment-methods")
+@bp.route("/payment-methods", methods=["GET"], provide_automatic_options=False)
 def list_payment_methods():
     uid, err = require_user_id()
     if err:
@@ -133,7 +133,7 @@ def list_payment_methods():
     return {"items": [to_dict(pm) for pm in items]}, 200
 
 
-@bp.post("/payment-methods")
+@bp.route("/payment-methods", methods=["POST"], provide_automatic_options=False)
 def create_payment_method():
     uid, err = require_user_id()
     if err:
@@ -159,7 +159,7 @@ def create_payment_method():
     return to_dict(pm), 201
 
 
-@bp.put("/payment-methods/<int:payment_method_id>")
+@bp.route("/payment-methods/<int:payment_method_id>", methods=["PUT"], provide_automatic_options=False)
 def replace_payment_method(payment_method_id: int):
     uid, err = require_user_id()
     if err:
@@ -182,7 +182,7 @@ def replace_payment_method(payment_method_id: int):
     return to_dict(pm), 200
 
 
-@bp.patch("/payment-methods/<int:payment_method_id>")
+@bp.route("/payment-methods/<int:payment_method_id>", methods=["PATCH"], provide_automatic_options=False)
 def update_payment_method(payment_method_id: int):
     uid, err = require_user_id()
     if err:
@@ -207,7 +207,7 @@ def update_payment_method(payment_method_id: int):
     return to_dict(pm), 200
 
 
-@bp.delete("/payment-methods/<int:payment_method_id>")
+@bp.route("/payment-methods/<int:payment_method_id>", methods=["DELETE"], provide_automatic_options=False)
 def delete_payment_method(payment_method_id: int):
     uid, err = require_user_id()
     if err:
@@ -236,11 +236,22 @@ def delete_payment_method(payment_method_id: int):
 
 
 # Optional: explicit OPTIONS for these resources (already have /api/options, but this is cleaner)
+from flask import make_response
+
 @bp.route("/payment-methods", methods=["OPTIONS"])
-@bp.route("/payment-methods/<int:payment_method_id>", methods=["OPTIONS"])
-def payment_methods_options(payment_method_id: int | None = None):
+def payment_methods_options_collection():
     resp = make_response("", 204)
-    resp.headers["Allow"] = "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    resp.headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    allow = "GET,POST,OPTIONS"
+    resp.headers["Allow"] = allow
+    resp.headers["Access-Control-Allow-Methods"] = allow
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    return resp
+
+@bp.route("/payment-methods/<int:payment_method_id>", methods=["OPTIONS"])
+def payment_methods_options_item(payment_method_id):
+    resp = make_response("", 204)
+    allow = "GET,PUT,PATCH,DELETE,OPTIONS"
+    resp.headers["Allow"] = allow
+    resp.headers["Access-Control-Allow-Methods"] = allow
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
     return resp


### PR DESCRIPTION
## Summary
This PR fixes CO-FUNC-009 by correcting OPTIONS behavior and endpoint registration for the Orders and Payment Methods modules.

## What changed
- Updated route decorators to disable Flask automatic OPTIONS on protected endpoints:
  - `routes/orders.py`
  - `routes/payment_methods.py`
- Replaced shortcut decorators (`@bp.get/@bp.post/...`) with explicit:
  - `@bp.route(..., methods=[...], provide_automatic_options=False)`
- Added explicit OPTIONS handlers for collection and item routes in both modules.
- Split OPTIONS handlers by resource shape and method set:
  - Collection routes return `GET,POST,OPTIONS`
  - Item routes return method sets appropriate to item operations
- Renamed OPTIONS handler functions to unique names to prevent endpoint function name collisions (Flask assertion on duplicate endpoint mapping).

## Why
- Ensures `OPTIONS /api/orders` and `OPTIONS /api/payment-methods` return stable, expected method metadata.
- Preserves auth enforcement on protected routes while allowing preflight/introspection requests.
- Removes Flask endpoint overwrite errors caused by duplicate function names.

## Validation
- Functional scenario CO-FUNC-009 now passes:
  - OPTIONS checks for module endpoints
  - 401 enforcement for protected routes remains intact
